### PR TITLE
[TASK] Adjust/Integrate Fluid property variables

### DIFF
--- a/packages/zingcarinfo/Resources/Private/Partials/SellerInfo/Properties.html
+++ b/packages/zingcarinfo/Resources/Private/Partials/SellerInfo/Properties.html
@@ -5,6 +5,7 @@
 			<f:translate key="tx_zingcarinfo_domain_model_sellerinfo.seller_id" />
 		</td>
 		<td>
+			{sellerInfo.sellerId}
 		</td>
 	</tr>
 	<tr>
@@ -12,6 +13,7 @@
 			<f:translate key="tx_zingcarinfo_domain_model_sellerinfo.seller_name" />
 		</td>
 		<td>
+			{sellerInfo.sellerName}
 		</td>
 	</tr>
 	<tr>
@@ -19,6 +21,7 @@
 			<f:translate key="tx_zingcarinfo_domain_model_sellerinfo.seller_contact" />
 		</td>
 		<td>
+			{sellerInfo.sellerContact}
 		</td>
 	</tr>
 	<tr>
@@ -26,6 +29,7 @@
 			<f:translate key="tx_zingcarinfo_domain_model_sellerinfo.car_id" />
 		</td>
 		<td>
+			{sellerInfo.carId}
 		</td>
 	</tr>
 </table>

--- a/packages/zingcarinfo/ext_localconf.php
+++ b/packages/zingcarinfo/ext_localconf.php
@@ -70,4 +70,3 @@ call_user_func(
 		
     }
 );
-00

--- a/public/typo3conf/PackageStates.php
+++ b/public/typo3conf/PackageStates.php
@@ -101,6 +101,9 @@ return [
         'bootstrap_package' => [
             'packagePath' => 'typo3conf/ext/bootstrap_package/',
         ],
+        'zing_application' => [
+            'packagePath' => 'typo3conf/ext/zing_application/',
+        ],
         'extension_builder' => [
             'packagePath' => 'typo3conf/ext/extension_builder/',
         ],


### PR DESCRIPTION
Let's have a look into the rendering chain, assumed that currently `SellerInfo` controller has been called with `show` action - templates can be found in general in `Resources/Templates/<Controller>/<Action>.html`

* https://github.com/sblacksmith/zing-app-icw/blob/53cdb895f6c7ada70c0e5eb041ef975a5cd51ed3/packages/zingcarinfo/Resources/Private/Templates/SellerInfo/Show.html#L19 - this line forwards rendering to a partial and submitting the variable `sellerInfo` (1st) filled with `sellerInfo` object (2nd)
* https://github.com/sblacksmith/zing-app-icw/blob/53cdb895f6c7ada70c0e5eb041ef975a5cd51ed3/packages/zingcarinfo/Resources/Private/Partials/SellerInfo/Properties.html#L5 - thats the partial being referenced with has information in variable `sellerInfo` (which is in this case an object of https://github.com/sblacksmith/zing-app-icw/blob/53cdb895f6c7ada70c0e5eb041ef975a5cd51ed3/packages/zingcarinfo/Classes/Domain/Model/SellerInfo.php)
* however the partial just contains these `<f:translate>` labels (substituted with with values from https://github.com/sblacksmith/zing-app-icw/blob/53cdb895f6c7ada70c0e5eb041ef975a5cd51ed3/packages/zingcarinfo/Resources/Private/Language/locallang.xlf) without actually showing real values of the `SellerInfo` entity
* see the `<td></td>` blocks without having any data
* those should be e.g. `<td>{sellerInfo.sellerName}</td>`
* it's possible to utility `<f:debug>{sellerInfo}</f:debug>` in order to output all available properties of the according object